### PR TITLE
introduced model interface IPerson

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,20 +3,16 @@ import logo from './logo.svg';
 import './App.css';
 import List from './components/List';
 import AddToList from './components/AddToList';
+import {IPerson} from "./models/IPerson";
 
-export interface IState {
-  people: {
-      name: string
-      age: number
-      img: string
-      note?: string
-  }[]
+interface IState {
+  people: IPerson[]
 }
 
 
 function App() {
 
-  const [people, setPeople] = useState<IState["people"]>([
+  const [people, setPeople] = useState<IPerson[]>([
     {
       name: "LeBron James",
       age: 35,

--- a/src/components/AddToList.tsx
+++ b/src/components/AddToList.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
-import { IState as Props } from "../App";
+import {IPerson} from "../models/IPerson";
+
 
 interface IProps {
-    setPeople: React.Dispatch<React.SetStateAction<Props["people"]>>
-    people: Props["people"]
+    setPeople: React.Dispatch<React.SetStateAction<IPerson[]>>
+    people: IPerson[]
 }
 
 const AddToList: React.FC<IProps> = ({setPeople, people}) => {
@@ -32,7 +33,7 @@ const AddToList: React.FC<IProps> = ({setPeople, people}) => {
                 age: parseInt(input.age),
                 img: input.img,
                 note: input.note
-            }
+            } as IPerson
         ]);
 
         setInput({

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { IState as Props } from "../App";
+import {IPerson} from "../models/IPerson";
 
 interface IProps {
-    people: Props["people"]
+    people: IPerson[]
 }
 
 const List: React.FC<IProps> = ({ people }) => {

--- a/src/models/IPerson.ts
+++ b/src/models/IPerson.ts
@@ -1,0 +1,6 @@
+export interface IPerson {
+    name: string;
+    age: number;
+    img: string;
+    note?: string;
+}


### PR DESCRIPTION
Hi @harblaith7 

I just finished your tutorial about react and typescript. Well done, I think I got the point. However, one issue left me puzzled. As someone with a strong background in typed languages (say: 20 years of Java, C#) I am still trying to figure out why you are poking around with exporting the IState as a whole, importing it under a different name and then accessing the nested type on it in several components. IMHO this introduces unnecesary coupling and is an accident waiting to happen (quite similar to what uncle Bob calls "Train Wrecks")

For me it would be the most obvious to define the reappearing model type strictly and use it in different "envelopes", like IProps and IState. This type would also be the location of shared business rules like "age must be greater than 21" or something like that.

is there a good reason not to do it like in this PR?